### PR TITLE
hp firefly g11 fixes for nixos 24.11

### DIFF
--- a/modules/desktop.nix
+++ b/modules/desktop.nix
@@ -22,7 +22,7 @@ in {
         };
 
         # Remove unused programs
-        environment.gnome.excludePackages = (with pkgs.gnome; [
+        environment.gnome.excludePackages = (with pkgs; [
           epiphany # webbrowser use firefox
           geary # email reader
         ]);


### PR DESCRIPTION
- **Fix gnome warnings**
- **hp(firefly): Use new nixos-hardware**
