### PR TITLE
feat: add security module (Secure Boot + ParetoSecurity) [Ark 727]

### DIFF
--- a/docs/secureboot-setup.md
+++ b/docs/secureboot-setup.md
@@ -1,0 +1,128 @@
+# Secure Boot Setup with Lanzaboote
+
+Guide for enabling Secure Boot on NixOS hosts using lanzaboote.
+
+## Prerequisites
+
+- NixOS installed in UEFI mode
+- systemd-boot as the current bootloader
+- LUKS full disk encryption (recommended alongside Secure Boot)
+- Backup or familiarity with recovery tools (Live USB)
+
+## Supported Hardware
+
+Tested and confirmed working on Lenovo ThinkPads and Framework notebooks.
+
+## Module
+
+The `modules/security/secureboot.nix` module wraps lanzaboote with standard module options:
+
+```nix
+midgard.pc.security.secureboot.enable = true;
+# Optional: override PKI bundle path (default: /var/lib/sbctl)
+# midgard.pc.security.secureboot.pkiBundle = "/var/lib/sbctl";
+```
+
+The module is not included in the default imports — add `./modules/security` to your host
+imports or ensure the `default` nixosModule is used and enable it explicitly.
+
+## Step-by-Step
+
+### 1. Import the module in the host config
+
+```nix
+imports = [
+  # ...existing imports...
+  ../../modules/security
+];
+```
+
+### 2. Generate Secure Boot signing keys
+
+Before enabling the module, create the keys on the target machine:
+
+```bash
+sudo sbctl create-keys
+```
+
+This creates keys in `/var/lib/sbctl/`. Verify:
+
+```bash
+sudo sbctl status
+```
+
+### 3. Enable the module
+
+```nix
+midgard.pc.security.secureboot.enable = true;
+```
+
+Rebuild:
+
+```bash
+sudo nixos-rebuild switch --flake .#<hostname>
+```
+
+### 4. Verify signing
+
+After rebuild, check that all boot files are signed:
+
+```bash
+sudo sbctl verify
+```
+
+All entries should show as signed. If any are unsigned, investigate before proceeding.
+
+### 5. Reboot and check
+
+Reboot and verify lanzaboote is working:
+
+```bash
+bootctl status
+```
+
+At this point, Secure Boot is still in setup mode (not enforcing).
+
+### 6. Enable Secure Boot in UEFI
+
+1. Reboot into UEFI firmware settings (`systemctl reboot --firmware-setup`)
+2. Navigate to Security > Secure Boot
+3. Reset Secure Boot to Setup Mode (clear existing keys)
+4. Save and exit
+5. Boot into NixOS — sbctl will auto-enroll keys on first boot
+6. Reboot into UEFI again
+7. Enable Secure Boot enforcement
+8. Save and boot
+
+### 7. Confirm Secure Boot is active
+
+```bash
+bootctl status
+# Should show: Secure Boot: enabled (user)
+
+sbctl status
+# Should show: Secure Boot: enabled
+```
+
+## Recovery
+
+If the system fails to boot after enabling Secure Boot:
+
+1. Enter UEFI firmware settings
+2. Disable Secure Boot
+3. Boot normally
+4. Debug with `sudo sbctl verify` and check for unsigned files
+5. Re-enable Secure Boot once resolved
+
+Alternatively, boot from a Live USB and mount the root filesystem to inspect/fix the configuration.
+
+## Persisting Keys
+
+The PKI bundle at `/var/lib/sbctl` must persist across rebuilds. On standard NixOS installs
+(non-impermanence), this directory persists by default. If using impermanence, add
+`/var/lib/sbctl` to your persistent directories.
+
+## References
+
+- [lanzaboote repository](https://github.com/nix-community/lanzaboote)
+- [NixOS Wiki: Lanzaboote](https://wiki.nixos.org/wiki/Lanzaboote)

--- a/flake.lock
+++ b/flake.lock
@@ -1,5 +1,81 @@
 {
   "nodes": {
+    "crane": {
+      "locked": {
+        "lastModified": 1777830388,
+        "narHash": "sha256-2uoQAqUk2H0ijQtGiWAyNeQYGYc6yfAcRRLlJAz4Gp8=",
+        "owner": "ipetkov",
+        "repo": "crane",
+        "rev": "d459c1350e96ce1a7e3859c513ef5e9869d67d6f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "ipetkov",
+        "repo": "crane",
+        "type": "github"
+      }
+    },
+    "flake-compat": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1767039857,
+        "narHash": "sha256-vNpUSpF5Nuw8xvDLj2KCwwksIbjua2LZCqhV1LNRDns=",
+        "owner": "NixOS",
+        "repo": "flake-compat",
+        "rev": "5edf11c44bc78a0d334f6334cdaf7d60d732daab",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
+    "gitignore": {
+      "inputs": {
+        "nixpkgs": [
+          "lanzaboote",
+          "pre-commit",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1709087332,
+        "narHash": "sha256-HG2cCnktfHsKV0s4XW83gU3F57gaTljL9KNSuG6bnQs=",
+        "owner": "hercules-ci",
+        "repo": "gitignore.nix",
+        "rev": "637db329424fd7e46cf4185293b9cc8c88c95394",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "gitignore.nix",
+        "type": "github"
+      }
+    },
+    "lanzaboote": {
+      "inputs": {
+        "crane": "crane",
+        "nixpkgs": [
+          "nixpkgs"
+        ],
+        "pre-commit": "pre-commit",
+        "rust-overlay": "rust-overlay"
+      },
+      "locked": {
+        "lastModified": 1777882242,
+        "narHash": "sha256-9Ynx+ort1aSwReiCfkbgMS3Q6y+MPcekDoUWx9N3a7A=",
+        "owner": "nix-community",
+        "repo": "lanzaboote",
+        "rev": "04723d4fd6bde2665fef3b25856aeebbd4013c16",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "lanzaboote",
+        "type": "github"
+      }
+    },
     "nixpkgs": {
       "locked": {
         "lastModified": 1771903837,
@@ -14,11 +90,56 @@
         "type": "indirect"
       }
     },
+    "pre-commit": {
+      "inputs": {
+        "flake-compat": "flake-compat",
+        "gitignore": "gitignore",
+        "nixpkgs": [
+          "lanzaboote",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1776796298,
+        "narHash": "sha256-PcRvlWayisPSjd0UcRQbhG8Oqw78AcPE6x872cPRHN8=",
+        "owner": "cachix",
+        "repo": "pre-commit-hooks.nix",
+        "rev": "3cfd774b0a530725a077e17354fbdb87ea1c4aad",
+        "type": "github"
+      },
+      "original": {
+        "owner": "cachix",
+        "repo": "pre-commit-hooks.nix",
+        "type": "github"
+      }
+    },
     "root": {
       "inputs": {
+        "lanzaboote": "lanzaboote",
         "nixpkgs": "nixpkgs",
         "sops-nix": "sops-nix",
         "treefmt-nix": "treefmt-nix"
+      }
+    },
+    "rust-overlay": {
+      "inputs": {
+        "nixpkgs": [
+          "lanzaboote",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1777778183,
+        "narHash": "sha256-Lqv9MZO0XAGcMbXJU+ULBSMD41Pf391uJehylUQKe7Y=",
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "rev": "dbba5f888c82ef3ce594c451c33ac2474eb80847",
+        "type": "github"
+      },
+      "original": {
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "type": "github"
       }
     },
     "sops-nix": {

--- a/flake.nix
+++ b/flake.nix
@@ -6,6 +6,8 @@
     sops-nix.inputs.nixpkgs.follows = "nixpkgs";
     treefmt-nix.url = "github:numtide/treefmt-nix";
     treefmt-nix.inputs.nixpkgs.follows = "nixpkgs";
+    lanzaboote.url = "github:nix-community/lanzaboote";
+    lanzaboote.inputs.nixpkgs.follows = "nixpkgs";
   };
 
   outputs =

--- a/flake.nix
+++ b/flake.nix
@@ -65,6 +65,7 @@
               ./modules/local.nix
               ./modules/nix-access-tokens.nix
               ./modules/ssh.nix
+              ./modules/security
             ];
           };
           terminal = {

--- a/modules/security/default.nix
+++ b/modules/security/default.nix
@@ -1,0 +1,6 @@
+{ ... }: {
+  imports = [
+    ./paretosecurity.nix
+    ./secureboot.nix
+  ];
+}

--- a/modules/security/paretosecurity.nix
+++ b/modules/security/paretosecurity.nix
@@ -1,0 +1,54 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+with lib;
+
+let
+  cfg = config.midgard.pc.security.paretosecurity;
+
+  linkScript = pkgs.writeShellScript "paretosecurity-link" ''
+    config="$HOME/.config/pareto.toml"
+    if [ -f "$config" ]; then
+      team_id=$(grep '^TeamID' "$config" | cut -d'"' -f2)
+      [ -n "$team_id" ] && exit 0
+    fi
+    exec ${pkgs.paretosecurity}/bin/paretosecurity link '${cfg.inviteUrl}'
+  '';
+in
+{
+  options.midgard.pc.security.paretosecurity = {
+    enable = mkEnableOption "ParetoSecurity agent";
+
+    inviteUrl = mkOption {
+      type = with types; nullOr str;
+      default = null;
+      description = ''
+        Team invite URL for automatic device enrollment.
+        Format: paretosecurity://linkDevice?invite_id=<ID>
+        Obtain from the ParetoSecurity team dashboard or Keeper vault.
+        If unset, run paretosecurity link <url> manually after install.
+      '';
+    };
+  };
+
+  config = mkIf cfg.enable {
+    environment.systemPackages = [ pkgs.paretosecurity ];
+
+    systemd.user.services.paretosecurity-link = mkIf (cfg.inviteUrl != null) {
+      description = "Link device to ParetoSecurity team";
+      wantedBy = [ "default.target" ];
+      serviceConfig = {
+        Type = "oneshot";
+        RemainAfterExit = true;
+        ExecStart = linkScript;
+        Restart = "on-failure";
+        RestartSec = "30s";
+      };
+      startLimitIntervalSec = 300;
+      startLimitBurst = 5;
+    };
+  };
+}

--- a/modules/security/secureboot.nix
+++ b/modules/security/secureboot.nix
@@ -1,0 +1,36 @@
+{
+  config,
+  lib,
+  pkgs,
+  inputs,
+  ...
+}:
+with lib;
+
+let
+  cfg = config.midgard.pc.security.secureboot;
+in
+{
+  imports = [ inputs.lanzaboote.nixosModules.lanzaboote ];
+
+  options.midgard.pc.security.secureboot = {
+    enable = mkEnableOption "Secure Boot via lanzaboote";
+
+    pkiBundle = mkOption {
+      type = types.str;
+      default = "/var/lib/sbctl";
+      description = "Path to the Secure Boot PKI bundle managed by sbctl";
+    };
+  };
+
+  config = mkIf cfg.enable {
+    environment.systemPackages = [ pkgs.sbctl ];
+
+    boot.loader.systemd-boot.enable = mkForce false;
+
+    boot.lanzaboote = {
+      enable = true;
+      pkiBundle = cfg.pkiBundle;
+    };
+  };
+}


### PR DESCRIPTION
## Summary

- Adds `modules/security/` with two sub-modules wired into the default nixosModule
  - `secureboot.nix`: Secure Boot via lanzaboote; adds `lanzaboote` flake input; options under `midgard.pc.security.secureboot` (disabled by default, opt-in per host)
  - `paretosecurity.nix`: ParetoSecurity agent via nixpkgs-unstable overlay (required to pass Pareto's own version checks); options under `midgard.pc.security.paretosecurity` (disabled by default pending invite
URL — tracked in ARK-745); includes a systemd user service that auto-enrolls the device into the team workspace on first login when `inviteUrl` is set
- Adds `docs/secureboot-setup.md` with step-by-step setup guide

## Enabling Secure Boot on a host

```nix
midgard.pc.security.secureboot.enable = true;
```

See docs/secureboot-setup.md for the full key-generation and UEFI enrollment steps.

Enabling ParetoSecurity

Blocked on ARK-745 (obtain workspace invite URL). Once resolved:

```nix
midgard.pc.security.paretosecurity = {
  enable = true;
  inviteUrl = "paretosecurity://linkDevice?invite_id=<ID>";
};
```