### PR TITLE
feat: add developer PC backup to Azure Blob Storage

### DIFF
--- a/docs/backup.md
+++ b/docs/backup.md
@@ -1,0 +1,83 @@
+# Developer PC Backup
+
+Back up developer PC state to Azure Blob Storage using `rclone`. Each developer's backup is isolated to their own directory via ADLS Gen2 ACLs — only the user who created the backup (and admins) can access it.
+
+## Prerequisites
+
+- Azure CLI installed and authenticated: `az login`
+- Your Entra ID account must be in the `yggdrasil-developers` or `yggdrasil-admins` group
+
+## What gets backed up
+
+| Category | Paths | Notes |
+|---|---|---|
+| Home directory | `~/` (entire home) | Excludes caches, `node_modules`, `target/`, `.venv/`, `.git/objects/`, disk images, Nix store paths |
+| SOPS age keys | `/root/.config/sops/` | Requires `sudo` |
+| System state | `/etc/machine-id`, `/etc/nixos/` | Machine identity and NixOS config |
+| Secure Boot | `/var/lib/sbctl/` | Only if Secure Boot is enabled; requires `sudo` |
+| Browser profiles | `~/.mozilla/firefox/`, `~/.config/google-chrome/`, `~/.config/chromium/` | Excluded by default — prompted interactively with size estimate |
+
+## Running a backup
+
+From this repo:
+
+```bash
+nix run .#backup
+```
+
+Or with options:
+
+```bash
+nix run .#backup -- --dry-run            # preview without transferring
+nix run .#backup -- --include-browser    # skip the interactive browser prompt
+nix run .#backup -- --verbose            # show detailed output for each step
+```
+
+## Where backups are stored
+
+Backups are synced to the `devpcs` Azure storage account in the `developer-pcs` container:
+
+```
+developer-pcs/
+  <username>/
+    <hostname>/
+      home/
+      sops/
+      system/
+        etc/
+        nixos/
+        sbctl/
+```
+
+Each run uses `rclone sync`, so the destination always reflects the current state of the machine. Azure Blob versioning can be enabled on the storage account if historical snapshots are needed.
+
+## Access control
+
+The storage account uses ADLS Gen2 (hierarchical namespace). No RBAC data-plane roles are assigned to developers — access is controlled entirely via ACLs:
+
+- The container root ACL grants `rwx` to both the developers and admins groups (set in Terraform)
+- On first backup, the script creates `<username>/<hostname>/` directories and sets ACLs to only allow the current user's Entra ID identity
+- Admins inherit `rwx` via the default ACL on the container root
+
+This means developers can create their own backup directories but cannot read other developers' backups.
+
+## Restoring from backup
+
+To restore files from a backup, use `rclone copy` in the opposite direction:
+
+```bash
+# Set up auth (same as the backup script)
+export RCLONE_AZUREBLOB_ACCOUNT="devpcs$(az account show --query 'id' -o tsv | cut -c1-8)"
+export RCLONE_AZUREBLOB_ENV_AUTH="true"
+
+# List what's in your backup
+rclone ls "azureblob:developer-pcs/$(whoami)/$(hostname)/"
+
+# Restore specific files
+rclone copy "azureblob:developer-pcs/$(whoami)/$(hostname)/home/.ssh/" ~/.ssh/
+rclone copy "azureblob:developer-pcs/$(whoami)/$(hostname)/sops/" /root/.config/sops/ --sudo
+```
+
+## Infrastructure
+
+The storage account and ACL configuration are defined in [yggdrasil](https://github.com/fornybar/yggdrasil) at `ginnungagap/main.tf.nix`.

--- a/docs/backup.md
+++ b/docs/backup.md
@@ -1,6 +1,6 @@
-# Developer PC Backup
+# Developer PC Backup & Restore
 
-Back up developer PC state to Azure Blob Storage using `rclone`. Each developer's backup is isolated to their own directory via ADLS Gen2 ACLs — only the user who created the backup (and admins) can access it.
+Back up and restore developer PC state to Azure Blob Storage using `rclone`. Each developer's backup is isolated to their own directory via ADLS Gen2 ACLs — only the user who created the backup (and admins) can access it.
 
 ## Prerequisites
 
@@ -11,11 +11,11 @@ Back up developer PC state to Azure Blob Storage using `rclone`. Each developer'
 
 | Category | Paths | Notes |
 |---|---|---|
-| Home directory | `~/` (entire home) | Excludes caches, `node_modules`, `target/`, `.venv/`, `.git/objects/`, disk images, Nix store paths |
-| SOPS age keys | `/root/.config/sops/` | Requires `sudo` |
+| Home directory | `~/` (entire home) | Excludes caches, build artifacts, docker volumes, `.git/objects/`, disk images, LLM models |
+| SOPS age keys | `/root/.config/sops/` | Elevated via sudo; critical for secret decryption |
 | System state | `/etc/machine-id`, `/etc/nixos/` | Machine identity and NixOS config |
-| Secure Boot | `/var/lib/sbctl/` | Only if Secure Boot is enabled; requires `sudo` |
-| Browser profiles | `~/.mozilla/firefox/`, `~/.config/google-chrome/`, `~/.config/chromium/` | Excluded by default — prompted interactively with size estimate |
+| Secure Boot | `/var/lib/sbctl/` | Only if Secure Boot is enabled; elevated via sudo |
+| Browser profiles | Firefox, Chrome, Chromium, Edge | Excluded by default — prompted interactively with size estimate |
 
 ## Running a backup
 
@@ -33,9 +33,30 @@ nix run .#backup -- --include-browser    # skip the interactive browser prompt
 nix run .#backup -- --verbose            # show detailed output for each step
 ```
 
+## Restoring from backup
+
+```bash
+nix run .#restore
+```
+
+Or with options:
+
+```bash
+nix run .#restore -- --list                          # list available backups
+nix run .#restore -- --dry-run                       # preview full restore
+nix run .#restore -- sops                            # restore only SOPS keys
+nix run .#restore -- home sops                       # restore home and SOPS keys
+nix run .#restore -- --from-host old-pc home         # restore home from a different machine
+nix run .#restore -- --from-user alice --from-host x # restore from another user's backup (admins only)
+```
+
+Available categories: `home`, `sops`, `system`. If none specified, all are restored.
+
+Restore uses `rclone copy` (additive) — it only adds or updates files, never deletes local files that aren't in the backup.
+
 ## Where backups are stored
 
-Backups are synced to the `devpcs` Azure storage account in the `developer-pcs` container:
+Backups are synced to the `devpcs5111c8c6` Azure storage account (dev subscription) in the `developer-pcs` container:
 
 ```
 developer-pcs/
@@ -49,7 +70,7 @@ developer-pcs/
         sbctl/
 ```
 
-Each run uses `rclone sync`, so the destination always reflects the current state of the machine. Azure Blob versioning can be enabled on the storage account if historical snapshots are needed.
+Each backup run uses `rclone sync`, so the destination always reflects the current state of the machine.
 
 ## Access control
 
@@ -61,23 +82,6 @@ The storage account uses ADLS Gen2 (hierarchical namespace). No RBAC data-plane 
 
 This means developers can create their own backup directories but cannot read other developers' backups.
 
-## Restoring from backup
-
-To restore files from a backup, use `rclone copy` in the opposite direction:
-
-```bash
-# Set up auth (same as the backup script)
-export RCLONE_AZUREBLOB_ACCOUNT="devpcs$(az account show --query 'id' -o tsv | cut -c1-8)"
-export RCLONE_AZUREBLOB_ENV_AUTH="true"
-
-# List what's in your backup
-rclone ls "azureblob:developer-pcs/$(whoami)/$(hostname)/"
-
-# Restore specific files
-rclone copy "azureblob:developer-pcs/$(whoami)/$(hostname)/home/.ssh/" ~/.ssh/
-rclone copy "azureblob:developer-pcs/$(whoami)/$(hostname)/sops/" /root/.config/sops/ --sudo
-```
-
 ## Infrastructure
 
-The storage account and ACL configuration are defined in [yggdrasil](https://github.com/fornybar/yggdrasil) at `ginnungagap/main.tf.nix`.
+The storage account and ACL configuration are defined in [yggdrasil](https://github.com/fornybar/yggdrasil) at `ginnungagap/devpcs.dev.tf.nix` (dev-only).

--- a/flake.nix
+++ b/flake.nix
@@ -114,6 +114,24 @@
           program = "${script}/bin/pc-backup";
         };
 
+      apps."x86_64-linux".restore =
+        let
+          script = pkgs.writeShellApplication {
+            name = "pc-restore";
+            runtimeInputs = with pkgs; [
+              azure-cli
+              rclone
+              coreutils
+              gawk
+            ];
+            text = builtins.readFile ./scripts/restore.sh;
+          };
+        in
+        {
+          type = "app";
+          program = "${script}/bin/pc-restore";
+        };
+
       herculesCI = { };
 
       devShells."x86_64-linux".default = pkgs.mkShell {

--- a/flake.nix
+++ b/flake.nix
@@ -95,6 +95,25 @@
 
       templates = import ./templates;
 
+      apps."x86_64-linux".backup =
+        let
+          script = pkgs.writeShellApplication {
+            name = "pc-backup";
+            runtimeInputs = with pkgs; [
+              azure-cli
+              rclone
+              coreutils
+              gawk
+              sudo
+            ];
+            text = builtins.readFile ./scripts/backup.sh;
+          };
+        in
+        {
+          type = "app";
+          program = "${script}/bin/pc-backup";
+        };
+
       herculesCI = { };
 
       devShells."x86_64-linux".default = pkgs.mkShell {

--- a/scripts/backup.sh
+++ b/scripts/backup.sh
@@ -1,0 +1,260 @@
+STORAGE_ACCOUNT="devpcs5111c8c6"
+CONTAINER="developer-pcs"
+HOSTNAME="$(hostname)"
+REMOTE=":azureblob,account=${STORAGE_ACCOUNT},env_auth:"
+
+usage() {
+  echo "Usage: $(basename "$0") [--dry-run] [--include-browser] [--verbose]"
+  echo ""
+  echo "Backup developer PC state to Azure Blob Storage."
+  echo "Requires: az login (Azure CLI authentication)"
+  echo ""
+  echo "Options:"
+  echo "  --dry-run           Show what would be transferred without doing it"
+  echo "  --include-browser   Include browser profiles (can be large)"
+  echo "  --verbose           Show detailed output for each step"
+  echo "  -h, --help          Show this help"
+  exit 0
+}
+
+DRY_RUN=""
+INCLUDE_BROWSER=""
+VERBOSE=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --dry-run) DRY_RUN="--dry-run"; shift ;;
+    --include-browser) INCLUDE_BROWSER=1; shift ;;
+    --verbose) VERBOSE=1; shift ;;
+    -h|--help) usage ;;
+    *) echo "Unknown option: $1"; usage ;;
+  esac
+done
+
+log() {
+  if [[ -n "$VERBOSE" ]]; then
+    echo "  $1"
+  fi
+}
+
+log "Checking Azure CLI authentication..."
+if ! az account show &>/dev/null; then
+  echo "Error: not logged in to Azure CLI. Run 'az login' first."
+  exit 1
+fi
+log "Authenticated to subscription: $(az account show --query name -o tsv)"
+
+USERNAME="$(whoami)"
+DEST_PATH="${USERNAME}/${HOSTNAME}"
+DEST="${REMOTE}${CONTAINER}/${DEST_PATH}"
+
+# Set up per-user ACL on first run only — default ACL propagates to children
+echo "==> Ensuring directory ACL for ${DEST_PATH}/"
+if az storage fs directory show \
+  --file-system "$CONTAINER" \
+  --name "$USERNAME" \
+  --account-name "$STORAGE_ACCOUNT" \
+  --auth-mode login &>/dev/null; then
+  log "Directory ${USERNAME}/ already exists, skipping ACL setup"
+else
+  log "First run — creating directories and setting ACLs"
+  log "Fetching Entra ID object ID..."
+  USER_OID="$(az ad signed-in-user show --query id -o tsv)"
+  log "Object ID: ${USER_OID}"
+
+  log "Creating directory ${USERNAME}/..."
+  az storage fs directory create \
+    --file-system "$CONTAINER" \
+    --name "$USERNAME" \
+    --account-name "$STORAGE_ACCOUNT" \
+    --auth-mode login
+
+  log "Setting ACL on ${USERNAME}/ (default ACL propagates to subdirectories)..."
+  az storage fs access set \
+    --acl "user:${USER_OID}:rwx,default:user:${USER_OID}:rwx" \
+    --path "$USERNAME" \
+    --file-system "$CONTAINER" \
+    --account-name "$STORAGE_ACCOUNT" \
+    --auth-mode login
+
+  log "Creating directory ${DEST_PATH}/..."
+  az storage fs directory create \
+    --file-system "$CONTAINER" \
+    --name "$DEST_PATH" \
+    --account-name "$STORAGE_ACCOUNT" \
+    --auth-mode login
+fi
+
+HOME_DIR="$HOME"
+
+home_excludes() {
+  cat <<'EXCLUDES'
+- .cache/**
+- .nix-defexpr/**
+- .nix-profile/**
+- .local/state/**
+- .local/share/Trash/**
+- .local/share/docker/**
+- .local/share/uv/**
+- .local/share/nvim/**
+- .local/share/pnpm/**
+- .local/share/opencode/**
+- .git/objects/**
+- .direnv/**
+- node_modules/**
+- .npm/**
+- .bun/install/**
+- .cargo/registry/**
+- .cargo/git/**
+- .rustup/toolchains/**
+- .rustup/tmp/**
+- target/**
+- __pycache__/**
+- .venv/**
+- .local/share/pip/**
+- .local/share/virtualenvs/**
+- .cache/pip/**
+- go/pkg/**
+- .go/pkg/**
+- .cache/go-build/**
+- .gradle/**
+- .m2/repository/**
+- .nuget/**
+- .kube/cache/**
+- .mozilla/firefox/*/cache2/**
+- .mozilla/firefox/*/startupCache/**
+- .config/google-chrome/**/Cache/**
+- .config/google-chrome/**/Service Worker/**
+- .config/google-chrome/**/Code Cache/**
+- .config/google-chrome/**/GPUCache/**
+- .config/google-chrome/**/GrShaderCache/**
+- .config/chromium/**/Cache/**
+- .config/chromium/**/Service Worker/**
+- .config/chromium/**/Code Cache/**
+- .config/chromium/**/GPUCache/**
+- .config/chromium/**/GrShaderCache/**
+- .config/microsoft-edge/**/Cache/**
+- .config/microsoft-edge/**/Service Worker/**
+- .config/microsoft-edge/**/Code Cache/**
+- .config/microsoft-edge/**/GPUCache/**
+- .config/microsoft-edge/**/GrShaderCache/**
+- .config/obsidian/Cache/**
+- .config/Slack/Cache/**
+- .config/Slack/Code Cache/**
+- .config/Slack/GPUCache/**
+- .config/Slack/Service Worker/**
+- .claude/file-history/**
+- .claude/plugins/cache/**
+- .amp/**
+- .fopencode/**
+- .codex-personal/**
+- .copilot/**
+- .gemini/**
+- .docker/buildx/**
+- **/docker/volumes/**
+- **/docker-compose/**/data/**
+- .duckdb/extensions/**
+- .bun/bin/**
+- .claude/plugins/marketplaces/**
+- docker-data/**
+- result
+- *.qcow2
+- *.iso
+- *.img
+- *.gguf
+EXCLUDES
+}
+
+browser_dirs=(
+  ".mozilla/firefox"
+  ".config/google-chrome"
+  ".config/chromium"
+  ".config/microsoft-edge"
+)
+
+has_browser=0
+browser_size=0
+for bdir in "${browser_dirs[@]}"; do
+  if [[ -d "$HOME_DIR/$bdir" ]]; then
+    has_browser=1
+    size=$(du -sb "$HOME_DIR/$bdir" 2>/dev/null | cut -f1)
+    browser_size=$((browser_size + size))
+  fi
+done
+
+if [[ -z "$INCLUDE_BROWSER" && "$has_browser" -eq 1 ]]; then
+  browser_mb=$((browser_size / 1024 / 1024))
+  echo ""
+  echo "Browser profiles found (~${browser_mb} MB before cache exclusions)."
+  read -rp "Include browser profiles in backup? [y/N] " answer
+  if [[ "$answer" =~ ^[Yy]$ ]]; then
+    INCLUDE_BROWSER=1
+  fi
+fi
+
+browser_exclude=""
+if [[ -z "$INCLUDE_BROWSER" ]]; then
+  browser_exclude="- .mozilla/**
+- .config/google-chrome/**
+- .config/chromium/**
+- .config/microsoft-edge/**"
+fi
+
+echo ""
+echo "Backing up to: ${STORAGE_ACCOUNT}/${CONTAINER}/${DEST_PATH}/"
+[[ -n "$DRY_RUN" ]] && echo "(DRY RUN)"
+echo ""
+
+echo "==> Home directory"
+rclone sync \
+  --filter-from <(home_excludes; echo "$browser_exclude") \
+  --ignore-errors \
+  --retries 1 \
+  $DRY_RUN \
+  --progress \
+  "$HOME_DIR" "${DEST}/home/" || echo "  (completed with some permission errors — skipped unreadable paths)"
+
+echo ""
+echo "==> SOPS age keys"
+sops_dir="/root/.config/sops"
+sops_tmp="$(mktemp -d)"
+trap '/run/wrappers/bin/sudo rm -rf "$sops_tmp"' EXIT
+if /run/wrappers/bin/sudo cp -a "$sops_dir/." "$sops_tmp/" 2>/dev/null; then
+  rclone sync \
+    $DRY_RUN \
+    --progress \
+    "$sops_tmp" "${DEST}/sops/"
+else
+  echo "  (skipped — could not read $sops_dir, run with sudo access)"
+fi
+
+echo ""
+echo "==> System state"
+rclone sync \
+  --include "/etc/machine-id" \
+  $DRY_RUN \
+  --progress \
+  /etc "${DEST}/system/etc/"
+
+if [[ -d /etc/nixos ]]; then
+  rclone sync \
+    $DRY_RUN \
+    --progress \
+    /etc/nixos "${DEST}/system/nixos/"
+fi
+
+if [[ -d /var/lib/sbctl ]]; then
+  sbctl_tmp="$(mktemp -d)"
+  trap '/run/wrappers/bin/sudo rm -rf "$sops_tmp" "$sbctl_tmp"' EXIT
+  if /run/wrappers/bin/sudo cp -a /var/lib/sbctl/. "$sbctl_tmp/" 2>/dev/null; then
+    rclone sync \
+      $DRY_RUN \
+      --progress \
+      "$sbctl_tmp" "${DEST}/system/sbctl/"
+  else
+    echo "  (skipped — could not read /var/lib/sbctl, run with sudo access)"
+  fi
+fi
+
+echo ""
+echo "Backup complete."

--- a/scripts/restore.sh
+++ b/scripts/restore.sh
@@ -1,0 +1,147 @@
+STORAGE_ACCOUNT="devpcs5111c8c6"
+CONTAINER="developer-pcs"
+REMOTE=":azureblob,account=${STORAGE_ACCOUNT},env_auth:"
+
+usage() {
+  echo "Usage: $(basename "$0") [--dry-run] [--verbose] [--from-user USER] [--from-host HOST] [CATEGORY...]"
+  echo ""
+  echo "Restore developer PC state from Azure Blob Storage."
+  echo "Requires: az login (Azure CLI authentication)"
+  echo ""
+  echo "Categories (default: all):"
+  echo "  home       Home directory config and files"
+  echo "  sops       SOPS age keys (/root/.config/sops)"
+  echo "  system     System state (machine-id, /etc/nixos, sbctl)"
+  echo ""
+  echo "Options:"
+  echo "  --dry-run              Show what would be restored without doing it"
+  echo "  --verbose              Show detailed output for each step"
+  echo "  --from-user USER       Restore from a different user's backup (default: current user)"
+  echo "  --from-host HOST       Restore from a different hostname (default: current hostname)"
+  echo "  --list                 List available backups and exit"
+  echo "  -h, --help             Show this help"
+  echo ""
+  echo "Examples:"
+  echo "  $(basename "$0") --dry-run                    # preview full restore"
+  echo "  $(basename "$0") sops                         # restore only SOPS keys"
+  echo "  $(basename "$0") --from-host old-pc home      # restore home from old machine"
+  exit 0
+}
+
+DRY_RUN=""
+VERBOSE=""
+FROM_USER="$(whoami)"
+FROM_HOST="$(hostname)"
+LIST_ONLY=""
+CATEGORIES=()
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --dry-run) DRY_RUN="--dry-run"; shift ;;
+    --verbose) VERBOSE=1; shift ;;
+    --from-user) FROM_USER="$2"; shift 2 ;;
+    --from-host) FROM_HOST="$2"; shift 2 ;;
+    --list) LIST_ONLY=1; shift ;;
+    -h|--help) usage ;;
+    home|sops|system) CATEGORIES+=("$1"); shift ;;
+    *) echo "Unknown option or category: $1"; usage ;;
+  esac
+done
+
+if [[ ${#CATEGORIES[@]} -eq 0 ]]; then
+  CATEGORIES=(home sops system)
+fi
+
+log() {
+  if [[ -n "$VERBOSE" ]]; then
+    echo "  $1"
+  fi
+}
+
+log "Checking Azure CLI authentication..."
+if ! az account show &>/dev/null; then
+  echo "Error: not logged in to Azure CLI. Run 'az login' first."
+  exit 1
+fi
+log "Authenticated to subscription: $(az account show --query name -o tsv)"
+
+SRC_PATH="${FROM_USER}/${FROM_HOST}"
+SRC="${REMOTE}${CONTAINER}/${SRC_PATH}"
+
+if [[ -n "$LIST_ONLY" ]]; then
+  echo "Available backups:"
+  rclone lsd "${REMOTE}${CONTAINER}/" 2>/dev/null | awk '{print $NF}' | while read -r user; do
+    rclone lsd "${REMOTE}${CONTAINER}/${user}/" 2>/dev/null | awk '{print $NF}' | while read -r host; do
+      echo "  ${user}/${host}"
+    done
+  done
+  exit 0
+fi
+
+echo "Restoring from: ${STORAGE_ACCOUNT}/${CONTAINER}/${SRC_PATH}/"
+[[ -n "$DRY_RUN" ]] && echo "(DRY RUN)"
+
+# Verify the source exists
+if ! rclone lsd "${SRC}/" &>/dev/null; then
+  echo "Error: backup not found at ${SRC_PATH}/"
+  echo "Run with --list to see available backups."
+  exit 1
+fi
+
+for cat in "${CATEGORIES[@]}"; do
+  case "$cat" in
+    home)
+      echo ""
+      echo "==> Restoring home directory"
+      rclone copy \
+        $DRY_RUN \
+        --progress \
+        "${SRC}/home/" "$HOME/"
+      ;;
+    sops)
+      echo ""
+      echo "==> Restoring SOPS age keys"
+      sops_tmp="$(mktemp -d)"
+      trap '/run/wrappers/bin/sudo rm -rf "$sops_tmp"' EXIT
+      rclone copy \
+        $DRY_RUN \
+        --progress \
+        "${SRC}/sops/" "$sops_tmp/"
+      if [[ -z "$DRY_RUN" ]]; then
+        /run/wrappers/bin/sudo mkdir -p /root/.config/sops
+        /run/wrappers/bin/sudo cp -a "$sops_tmp/." /root/.config/sops/
+        echo "  Restored to /root/.config/sops/"
+      fi
+      ;;
+    system)
+      echo ""
+      echo "==> Restoring system state"
+      if rclone lsd "${SRC}/system/nixos/" &>/dev/null; then
+        echo "  /etc/nixos/"
+        /run/wrappers/bin/sudo rclone copy \
+          $DRY_RUN \
+          --progress \
+          "${SRC}/system/nixos/" /etc/nixos/ 2>/dev/null || \
+          rclone copy $DRY_RUN --progress "${SRC}/system/nixos/" /tmp/restore-nixos/ && \
+          echo "  (copied to /tmp/restore-nixos/ — move to /etc/nixos/ manually)"
+      fi
+      if rclone lsd "${SRC}/system/sbctl/" &>/dev/null; then
+        echo "  /var/lib/sbctl/"
+        sbctl_tmp="$(mktemp -d)"
+        rclone copy \
+          $DRY_RUN \
+          --progress \
+          "${SRC}/system/sbctl/" "$sbctl_tmp/"
+        if [[ -z "$DRY_RUN" ]]; then
+          /run/wrappers/bin/sudo mkdir -p /var/lib/sbctl
+          /run/wrappers/bin/sudo cp -a "$sbctl_tmp/." /var/lib/sbctl/
+          /run/wrappers/bin/sudo rm -rf "$sbctl_tmp"
+          echo "  Restored to /var/lib/sbctl/"
+        fi
+      fi
+      ;;
+  esac
+done
+
+echo ""
+echo "Restore complete."


### PR DESCRIPTION
  ## Summary

  - Add `nix run .#backup` flake app that syncs the developer's home directory and system state to Azure Blob Storage via rclone
  - Backs up entire `~/` (excluding caches, build artifacts, nix store paths, disk images), SOPS age keys, `/etc/nixos`, `/etc/machine-id`, and sbctl state
  - Browser profiles excluded by default — interactive prompt shows estimated size and asks before including
  - Authenticates via `az login`; per-user directory ACLs set dynamically on first run using ADLS Gen2, so each developer's backup is only accessible to them (and admins)

  ## Companion PR

  Storage account infrastructure (`devpcs` with HNS) and root ACL configuration in [fornybar/yggdrasil](https://github.com/fornybar/yggdrasil) on branch `rjd/add-dev-machine-storage` — must be deployed before
  first use.

  ## Test plan

  - [x] Deploy `devpcs` storage account from yggdrasil
  - [x] Run `nix run .#backup -- --dry-run` to verify auth and file selection
  - [x] Run full backup and verify files in Azure Storage Explorer
  - [x] Confirm ACL isolation: second user cannot list first user's hostname directory
  - [x] Test restore flow per docs/backup.md instructions