### PR TITLE
Fix security module lanzaboote import

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -33,12 +33,19 @@
         lib.mapAttrs' (n: _: lib.nameValuePair (lib.removeSuffix ".nix" n) (import (dir + "/${n}"))) (
           builtins.readDir dir
         );
+      securityModule = {
+        imports = [
+          inputs.lanzaboote.nixosModules.lanzaboote
+          ./modules/security
+        ];
+      };
     in
     {
       nixosModules =
         import ./hardware
         // importDir ./modules
         // {
+          security = securityModule;
           default = {
             # Need to use path insted of self.nixosModules.xxxx
             # so it is possible to disable modules
@@ -65,7 +72,7 @@
               ./modules/local.nix
               ./modules/nix-access-tokens.nix
               ./modules/ssh.nix
-              ./modules/security
+              securityModule
             ];
           };
           terminal = {

--- a/modules/security/secureboot.nix
+++ b/modules/security/secureboot.nix
@@ -2,7 +2,6 @@
   config,
   lib,
   pkgs,
-  inputs,
   ...
 }:
 with lib;
@@ -11,8 +10,6 @@ let
   cfg = config.midgard.pc.security.secureboot;
 in
 {
-  imports = [ inputs.lanzaboote.nixosModules.lanzaboote ];
-
   options.midgard.pc.security.secureboot = {
     enable = mkEnableOption "Secure Boot via lanzaboote";
 


### PR DESCRIPTION
## Summary
- export security module as wrapper that imports pc-owned lanzaboote module
- make default module use same wrapper
- remove downstream inputs.lanzaboote lookup from secureboot module

## Test
- nix flake check