### PR TITLE
boot: make EFI mountpoint overridable

### DIFF
--- a/modules/boot.nix
+++ b/modules/boot.nix
@@ -1,4 +1,4 @@
-{ pkgs, ... }:
+{ pkgs, lib, ... }:
 {
   boot = {
     kernelPackages = pkgs.linuxPackages_latest;
@@ -9,7 +9,7 @@
       };
       efi = {
         canTouchEfiVariables = true;
-        efiSysMountPoint = "/boot";
+        efiSysMountPoint = lib.mkDefault "/boot";
       };
     };
     tmp.cleanOnBoot = true;


### PR DESCRIPTION
## Summary
- make the systemd-boot EFI mountpoint setting overridable with lib.mkDefault
- preserve the current upstream default of /boot

## Verification
- nix flake check --no-build