### PR TITLE
Reduce default bootloader timeout

### DIFF
--- a/modules/boot.nix
+++ b/modules/boot.nix
@@ -3,6 +3,7 @@
   boot = {
     kernelPackages = pkgs.linuxPackages_latest;
     loader = {
+      timeout = lib.mkDefault 1;
       systemd-boot = {
         enable = true;
         configurationLimit = 10;


### PR DESCRIPTION
## Summary

- reduce systemd-boot menu timeout from NixOS default of 5 seconds to 1 second
- use `lib.mkDefault` so hosts can override recovery/menu policy

## Rationale

Workstation boot profiling showed loader time as a meaningful fixed part of startup. One second preserves menu access while reducing normal startup delay.

NetworkManager wait-online remains unchanged: disabling it in a reusable module would weaken `network-online.target` semantics for downstream hosts.

## Validation

- `nix flake check`
- `git diff --check`